### PR TITLE
refactor to use double-pointer linked-list

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+# Disable comments on Pull Requests
+comment: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 package-lock.json
+.DS_Store
+coverage
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - 11
+  - 10
+  - 8
+  - 6
+after_success: npm run coverage

--- a/index.js
+++ b/index.js
@@ -1,108 +1,81 @@
-const Promise = require('any-promise')
+'use strict'
 
-function defer() {
-  let resolve
-  let reject
+const { deprecate } = require('util')
+const ChannelItem = require('./item')
 
-  const promise = new Promise((_resolve, _reject) => {
-    resolve = _resolve
-    reject = _reject
-  })
-
-  return {
-    promise,
-    resolve,
-    reject
-  }
-}
-
+/**
+ * The channel class uses a single-direction linked-list
+ * with two pointers to track the position of input and
+ * output cursors in a theoretically infinite sequence.
+ * By shifting the pointers, any event that has had both
+ * input and output completions will drop out of scope
+ * and get garbage collected automatically.
+ *
+ * Because the functional behaviour of a channel is a
+ * race between two sides, the internal linked-list will
+ * always cover only the span between the input and output
+ * pointers. This design enables optimal memory usage for
+ * a lossless stream.
+ *
+ * To finalize the sequence in a way that mirrors the
+ * behaviour of iterators, an error or close event will
+ * create an item in the list which forms a circular
+ * reference to itself. By doing this, future requests
+ * beyond the end of the sequence will just repeatedly
+ * return the final event indicating the done state.
+ */
 class Channel {
-  constructor() {
-    this.inputs = []
-    this.requests = []
-    this.final = null
+  constructor () {
+    this.input = new ChannelItem()
+    this.request = this.input
   }
 
-  give(value) {
-    let deferred
-    if (this.requests.length) {
-      deferred = this.requests.shift()
-    } else {
-      deferred = defer()
-      this.inputs.push(deferred)
-    }
-
-    deferred.resolve({
-      value,
-      done: false
-    })
-  }
-
-  take() {
-    if (this.final) {
-      return this.final.promise
-    }
-
-    let deferred
-    if (this.inputs.length) {
-      deferred = this.inputs.shift()
-    } else {
-      deferred = defer()
-      this.requests.push(deferred)
-    }
-
-    return deferred.promise
-  }
-
-  giveBack(value) {
-    let deferred
-    if (this.requests.length) {
-      deferred = this.requests.shift()
-    } else {
-      deferred = defer()
-      this.inputs.unshift(deferred)
-    }
-
-    deferred.resolve({
-      value,
-      done: false
-    })
-  }
-
-  error(err) {
-    const deferred = defer()
-    deferred.reject(err)
-    this.final = deferred
-
-    let request
-    while (request = this.requests.shift()) {
-      request.reject(err)
-    }
-  }
-
-  close(value) {
-    const data = {
-      value: value,
-      done: true
-    }
-
-    const deferred = defer()
-    deferred.resolve(data)
-    this.final = deferred
-
-    let request
-    while (request = this.requests.shift()) {
-      request.resolve(data)
-    }
+  give (value) {
+    const { input } = this
+    this.input = input.ensureNext()
+    input.send(value)
   }
 
   next () {
-    return this.take()
+    const { request } = this
+    this.request = request.ensureNext()
+    return request.promise
   }
 
-  [Symbol.asyncIterator]() {
+  giveBack (value) {
+    const { input, request } = this
+
+    // No pending requests or inputs
+    if (!request.next && !input.next) {
+      return this.give(value)
+    }
+
+    // If there are pending inputs, create a
+    // new request and move the request pointer
+    let item = input
+    if (request.next) {
+      item = request.wrap()
+      this.request = item
+    }
+
+    item.send(value)
+  }
+
+  error (error) {
+    this.input.error(error)
+  }
+
+  close () {
+    this.input.close()
+  }
+
+  [Symbol.asyncIterator] () {
     return this
   }
 }
+
+Channel.prototype.take = deprecate(function take () {
+  return this.next()
+}, 'The channel.take() function is deprecated, please use channel.next() or for await loops.')
 
 module.exports = Channel

--- a/item.js
+++ b/item.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const defer = require('any-deferred')
+
+class ChannelItem {
+  constructor () {
+    const { promise, resolve, reject } = defer()
+    this.promise = promise
+    this.resolve = resolve
+    this.reject = reject
+    this.next = null
+  }
+
+  // Non-destructive traversal--there may already be
+  // an input or output in the queue
+  ensureNext () {
+    if (!this.next) {
+      this.next = new ChannelItem()
+    }
+    return this.next
+  }
+
+  // This allows you to insert new items at the start
+  wrap () {
+    const item = new ChannelItem()
+    item.next = this
+    return item
+  }
+
+  send (value) {
+    this.value = value
+    this.resolve({
+      done: false,
+      value
+    })
+  }
+
+  error (error) {
+    this.reject(error)
+
+    // Ensure the tail is finalized
+    if (this.next) {
+      this.next.reject(error)
+    }
+    this.next = this
+  }
+
+  close (value) {
+    this.resolve({
+      done: true,
+      value
+    })
+
+    // Ensure the tail is finalized
+    if (this.next) {
+      this.next.close(value)
+    }
+    this.next = this
+  }
+}
+
+module.exports = ChannelItem

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Promise-based CSP channels",
   "main": "index.js",
   "scripts": {
-    "test": "tap test.js"
+    "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
+    "test": "standard && nyc tap test.js"
   },
   "keywords": [
     "csp",
@@ -14,11 +15,13 @@
   "author": "Stephen Belanger <admin@stephenbelanger.com>",
   "license": "MIT",
   "dependencies": {
-    "any-promise": "^1.3.0",
-    "bluebird": "^3.5.0"
+    "any-deferred": "^1.0.0"
   },
   "devDependencies": {
-    "tap": "^12.5.1"
+    "codecov": "^3.2.0",
+    "nyc": "^13.3.0",
+    "standard": "^12.0.1",
+    "tap": "^12.6.1"
   },
   "repository": {
     "type": "git",

--- a/test-10.js
+++ b/test-10.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const tap = require('tap')
+const Channel = require('./')
+
+tap.test('async iteration', async (t) => {
+  const channel = new Channel()
+  channel.give(1)
+  channel.give(2)
+  channel.close()
+
+  let i = 0
+  for await (let result of channel) {
+    t.equal(++i, result, `result is ${i}`)
+  }
+
+  t.equal(i, 2, `received ${i} items`)
+  t.end()
+})

--- a/test.js
+++ b/test.js
@@ -1,11 +1,39 @@
+'use strict'
+
 const tap = require('tap')
 const Channel = require('./')
 
-function uid() {
-  return new Buffer(Math.random().toString(35).substr(2, 16))
+function uid () {
+  return Buffer.from(Math.random().toString(35).substr(2, 16))
 }
 
-tap.test('give and take', async (t) => {
+tap.test('give then next - alternating', (t) => {
+  const channel = new Channel()
+  const tasks = []
+  const sent = []
+  const n = 100
+
+  for (let i = 0; i < n; i++) {
+    const value = uid()
+    channel.give(value)
+    tasks.push(channel.next())
+    sent.push(value)
+  }
+
+  return Promise.all(tasks).then((responses) => {
+    const received = responses
+      .filter(({ done }) => !done)
+      .map(({ value }) => value)
+
+    t.match(
+      Buffer.concat(received),
+      Buffer.concat(sent),
+      'received list matches sent list'
+    )
+  })
+})
+
+tap.test('give then next - bulk', (t) => {
   const channel = new Channel()
   const sent = []
   const n = 100
@@ -16,22 +44,76 @@ tap.test('give and take', async (t) => {
     sent.push(value)
   }
 
-  const tasks = sent.map(() => channel.take())
-  const responses = await Promise.all(tasks)
-  const received = responses
-    .filter(({ done }) => !done)
-    .map(({ value }) => value)
+  const tasks = sent.map(() => channel.next())
 
-  t.match(
-    Buffer.concat(received),
-    Buffer.concat(sent),
-    'received list matches sent list'
-  )
+  return Promise.all(tasks).then((responses) => {
+    const received = responses
+      .filter(({ done }) => !done)
+      .map(({ value }) => value)
 
-  t.end()
+    t.match(
+      Buffer.concat(received),
+      Buffer.concat(sent),
+      'received list matches sent list'
+    )
+  })
 })
 
-tap.test('give back', async (t) => {
+tap.test('next then give - alternating', (t) => {
+  const channel = new Channel()
+  const tasks = []
+  const sent = []
+  const n = 100
+
+  for (let i = 0; i < n; i++) {
+    const value = uid()
+    tasks.push(channel.next())
+    channel.give(value)
+    sent.push(value)
+  }
+
+  return Promise.all(tasks).then((responses) => {
+    const received = responses
+      .filter(({ done }) => !done)
+      .map(({ value }) => value)
+
+    t.match(
+      Buffer.concat(received),
+      Buffer.concat(sent),
+      'received list matches sent list'
+    )
+  })
+})
+
+tap.test('next then give - bulk', (t) => {
+  const channel = new Channel()
+  const tasks = []
+  const n = 100
+
+  for (let i = 0; i < n; i++) {
+    tasks.push(channel.next())
+  }
+
+  const sent = tasks.map(() => {
+    const value = uid()
+    channel.give(value)
+    return value
+  })
+
+  return Promise.all(tasks).then((responses) => {
+    const received = responses
+      .filter(({ done }) => !done)
+      .map(({ value }) => value)
+
+    t.match(
+      Buffer.concat(received),
+      Buffer.concat(sent),
+      'received list matches sent list'
+    )
+  })
+})
+
+tap.test('give back', (t) => {
   const channel = new Channel()
   const sent = []
   const n = 100
@@ -40,75 +122,157 @@ tap.test('give back', async (t) => {
     const value = uid()
     channel.give(value)
     sent.push(value)
+  }
+
+  const tasks = []
+  for (let i = 0; i < 10; i++) {
+    tasks.push(channel.next())
   }
 
   // Should return to original state after taking and giving back
-  const num = await channel.take()
-  t.match(num, {
-    value: sent[0],
-    done: false
-  })
-  channel.giveBack(num.value)
+  return Promise.all(tasks)
+    .then((nums) => {
+      t.equal(nums.length, 10)
+      // Loop backwards, so we giveBack in the right order
+      for (let i = 9; i >= 0; i--) {
+        const { done, value } = nums[i]
+        t.notOk(done)
+        t.equal(value, sent[i])
+        channel.giveBack(value)
+      }
+    })
+    .then(() => Promise.all(sent.map(() => channel.next())))
+    .then((responses) => {
+      const received = responses
+        .filter(({ done }) => !done)
+        .map(({ value }) => value)
 
-  const tasks = sent.map(() => channel.take())
-  const responses = await Promise.all(tasks)
-  const received = responses
-    .filter(({ done }) => !done)
-    .map(({ value }) => value)
-
-  t.match(
-    Buffer.concat(received),
-    Buffer.concat(sent),
-    'received list matches sent list'
-  )
-
-  t.end()
+      t.match(
+        Buffer.concat(received),
+        Buffer.concat(sent),
+        'received list matches sent list'
+      )
+    })
 })
 
-tap.test('error finalization', async (t) => {
+tap.test('give back to empty state', (t) => {
+  const channel = new Channel()
+
+  const expected = uid()
+  channel.giveBack(expected)
+
+  return channel.next()
+    .then(({ value }) => {
+      channel.close()
+      t.equal(value, expected)
+    })
+})
+
+tap.test('give back while waiting', (t) => {
+  const channel = new Channel()
+
+  const expected = uid()
+  channel.give(expected)
+
+  const a = channel.next()
+  const b = channel.next()
+
+  return a.then(({ value }) => {
+    channel.giveBack(value)
+    return b
+  }).then(({ value }) => {
+    t.equal(value, expected)
+  })
+})
+
+tap.test('error finalization', (t) => {
   const error = new Error('test')
   const channel = new Channel()
   channel.error(error)
 
   // End
-  try {
-    await channel.take()
-    t.fail('should have failed')
-  } catch (err) {
-    t.match(err, error, 'received error')
-  }
-
-  // End repeats due to finalization
-  try {
-    await channel.take()
-    t.fail('should have failed')
-  } catch (err) {
-    t.match(err, error, 'received error again')
-  }
-
-  t.end()
+  return channel.next()
+    .then(
+      () => t.fail('should have failed'),
+      (err) => t.match(err, error, 'received error')
+    )
+    // End repeats due to finalization
+    .then(() => channel.next())
+    .then(
+      () => t.fail('should have failed'),
+      (err) => t.match(err, error, 'received error again')
+    )
 })
 
-tap.test('close finalization', async (t) => {
+tap.test('error finalization while waiting', (t) => {
+  const error = new Error('test')
+  const channel = new Channel()
+  const a = channel.next()
+  channel.error(error)
+
+  // End
+  return a
+    .then(
+      () => t.fail('should have failed'),
+      (err) => t.match(err, error, 'received error')
+    )
+    // End repeats due to finalization
+    .then(() => channel.next())
+    .then(
+      () => t.fail('should have failed'),
+      (err) => t.match(err, error, 'received error again')
+    )
+})
+
+tap.test('close finalization', (t) => {
   const channel = new Channel()
   channel.close()
 
-  t.match(await channel.take(), { done: true }, 'received done flag')
-  t.match(await channel.take(), { done: true }, 'received done flag again')
-
-  t.end()
+  return channel.next()
+    .then(
+      (value) => t.match(value, { done: true }, 'received done flag'),
+      () => t.fail('should not have errored')
+    )
+    .then(() => channel.next())
+    .then(
+      (value) => t.match(value, { done: true }, 'received done flag again'),
+      () => t.fail('should not have errored')
+    )
 })
 
-tap.test('async iteration', async (t) => {
+tap.test('close finalization while waiting', (t) => {
   const channel = new Channel()
-  channel.give(1)
-  channel.give(2)
+  const a = channel.next()
   channel.close()
 
-  let i = 0
-  for await (let result of channel) {
-    t.equal(++i, result)
-  }
-
-  t.end()
+  return a
+    .then(
+      (value) => t.match(value, { done: true }, 'received done flag'),
+      () => t.fail('should not have errored')
+    )
+    .then(() => channel.next())
+    .then(
+      (value) => t.match(value, { done: true }, 'received done flag again'),
+      () => t.fail('should not have errored')
+    )
 })
+
+// Version-restricted tests
+const [ major ] = process.versions.node.split('.').map(Number)
+if (major >= 10) require('./test-10')
+
+if (major >= 8) {
+  tap.test('take emits deprecation warning', (t) => {
+    const emitWarning = process.emitWarning
+    process.emitWarning = (message) => {
+      t.equal(message, 'The channel.take() function is deprecated, please use channel.next() or for await loops.')
+      t.end()
+    }
+    t.on('end', () => {
+      process.emitWarning = emitWarning
+    })
+
+    const channel = new Channel()
+    channel.take()
+  })
+}


### PR DESCRIPTION
By using a linked-list with two moving pointers, much greater operation and memory efficiency can be achieved, This also makes for more predictable behaviour when one side of the channel is outrunning the other.